### PR TITLE
Run gas simulation

### DIFF
--- a/project/test/bet.js
+++ b/project/test/bet.js
@@ -42,4 +42,8 @@ contract("Bet", function(accounts){
 
     assert(newBalance.toNumber() > initialBalance.toNumber(), "Winner should have gotten something");
   });
+
+  it.only('simulate a deployment', async function(){
+    await Bet.new("0x6f485c8bf6fc43ea212e93bbf8ce046c7f1cb475");
+  });
 });

--- a/project/truffle.js
+++ b/project/truffle.js
@@ -31,5 +31,8 @@ module.exports = {
       network_id: "3",
       gas: 4000000
     }
+  },
+  mocha: {
+    reporter: "eth-gas-reporter"
   }
 };


### PR DESCRIPTION
This PR modifies the tests to run a simple simulation of deploying a `Bet` contract and uses `eth-gas-reporter` to calculate the deployments costs. Because the oraclize contracts are pre-deployed and there's the complication of `ethereum-bridge`, this simulation can only really be run as a test on it's own. It suggests that deploying a `Bet` costs ~2 million gas.
![screen shot 2018-03-05 at 7 51 36 pm](https://user-images.githubusercontent.com/7332026/37013508-238161f4-20af-11e8-8c89-4a968c82e63c.png)
